### PR TITLE
Prevent user dragging for improved UX

### DIFF
--- a/app.js
+++ b/app.js
@@ -123,6 +123,11 @@ animalElement.addEventListener("click", () => {
     endGame()
 })
 
+
+// Prevents elements on page being dragged by users 
+$('div').on('dragstart', function(event) { event.preventDefault(); });
+$('img').on('dragstart', function(event) { event.preventDefault(); });
+
 // Ensures lampshade swing animation finishes when mouse moved away
 $(document).ready(function () {
   $(".lamp").on("animationiteration", function () {


### PR DESCRIPTION
Until now, user has been able to drag elements such as images, bookshelf etc. 
This is easy to do by accident when clicking to find, and can mean accidentally dragging the cat image which ruins the UX. 
This change prevents user dragging.